### PR TITLE
Component test classpath no-longer extends main or test

### DIFF
--- a/componentTest-noGroovy.gradle
+++ b/componentTest-noGroovy.gradle
@@ -3,9 +3,6 @@ sourceSets {
         java {
             srcDir 'src/componentTest/java'
         }
-        groovy {
-            srcDir 'src/componentTest/groovy'
-        }
         resources {
             srcDir 'src/componentTest/resources'
         }


### PR DESCRIPTION
- Added componentTest-noGroovy for projects that don't include the Groovy plugin